### PR TITLE
chore: remove option to add note titles

### DIFF
--- a/src/components/Form/NoteFields.tsx
+++ b/src/components/Form/NoteFields.tsx
@@ -41,7 +41,7 @@ export default function NoteFields({
         ))}
       </ul>
       <Button
-        onClick={() => append({ title: "", body: "" })}
+        onClick={() => append({ body: "" })}
         className="justify-self-center"
       >
         <DocumentPlusIcon className="w-4" aria-hidden="true" />

--- a/src/types/applications.ts
+++ b/src/types/applications.ts
@@ -45,7 +45,6 @@ export const zodFullApplication = z.object({
   notes: z
     .array(
       z.object({
-        title: z.string(),
         body: z.string(),
       }),
     )
@@ -96,7 +95,6 @@ export type UpdateApplicationType = {
 };
 
 export type NotesType = {
-  title: string;
   body: string;
 };
 
@@ -147,7 +145,7 @@ export const formSchema = z.object({
       }),
     )
     .optional(),
-  notes: z.array(z.object({ title: z.string(), body: z.string() })).optional(),
+  notes: z.array(z.object({ body: z.string() })).optional(),
 });
 
 export type FormContextType = {


### PR DESCRIPTION
Remove option to add note titles.
Update types / zod schemas involving notes

Closes #49 