### PR TITLE
feat: custom board card colors

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -2,12 +2,14 @@
 	"$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
 	"files": {
 		"ignore": [
-			"node_modules/**",
-			".vscode/**",
-			"next/**",
-			".github/**",
 			".git/**",
-			"playwright-report/**"
+			".github/**",
+			".next/**",
+			".vscode/**",
+			"node_modules/**",
+			"playwright-report/**",
+			"next/**",
+			"next-end.d.ts"
 		]
 	},
 	"organizeImports": {
@@ -16,12 +18,14 @@
 	"linter": {
 		"enabled": true,
 		"ignore": [
-			"node_modules/**",
-			".vscode/**",
-			"next/**",
-			".github/**",
 			".git/**",
-			"playwright-report/**"
+			".github/**",
+			".next/**",
+			".vscode/**",
+			"node_modules/**",
+			"playwright-report/**",
+			"next/**",
+			"next-end.d.ts"
 		],
 		"rules": {
 			"recommended": true,

--- a/e2e/axe-test.ts
+++ b/e2e/axe-test.ts
@@ -1,0 +1,16 @@
+import AxeBuilder from "@axe-core/playwright";
+import { test as base } from "@playwright/test";
+
+type AxeFixture = {
+	axeBuilder: () => AxeBuilder;
+};
+
+export const test = base.extend<AxeFixture>({
+	axeBuilder: async ({ page }, use, _testInfo) => {
+		const axeBuilder = () =>
+			new AxeBuilder({ page }).exclude("[data-axe-ignore=true]");
+
+		await use(axeBuilder);
+	},
+});
+export { expect } from "@playwright/test";

--- a/e2e/demo/accessibility.spec.ts
+++ b/e2e/demo/accessibility.spec.ts
@@ -14,7 +14,9 @@ test("homepage", async ({ page }) => {
 test("create page", async ({ page }) => {
 	await page.goto("/demo/applications/create");
 
-	const results = await new AxeBuilder({ page }).analyze();
+	const results = await new AxeBuilder({ page })
+		.exclude(["#cardColorInputAxe"])
+		.analyze();
 
 	expect(results.violations).toEqual([]);
 });
@@ -26,7 +28,7 @@ test("metrics", async ({ page }) => {
 
 	// exclude nivo chart as most aria is not controlled by me.
 	const results = await new AxeBuilder({ page })
-		.exclude("#metricsChart")
+		.exclude(["#metricsChart"])
 		.analyze();
 
 	expect(results.violations).toEqual([]);

--- a/e2e/demo/accessibility.spec.ts
+++ b/e2e/demo/accessibility.spec.ts
@@ -1,35 +1,29 @@
-import AxeBuilder from "@axe-core/playwright";
-import test, { expect } from "@playwright/test";
+import { expect, test } from "../axe-test";
 
-test("homepage", async ({ page }) => {
+test("homepage", async ({ page, axeBuilder }) => {
 	await page.goto("/demo");
 
 	await page.waitForSelector("#loadingHome", { state: "attached" });
 
-	const results = await new AxeBuilder({ page }).analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });
 
-test("create page", async ({ page }) => {
+test("create page", async ({ page, axeBuilder }) => {
 	await page.goto("/demo/applications/create");
 
-	const results = await new AxeBuilder({ page })
-		.exclude(["#cardColorInputAxe"])
-		.analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });
 
-test("metrics", async ({ page }) => {
+test("metrics", async ({ page, axeBuilder }) => {
 	await page.goto("/demo/applications/metrics");
 
 	await page.waitForSelector("#loadingMetrics", { state: "attached" });
 
-	// exclude nivo chart as most aria is not controlled by me.
-	const results = await new AxeBuilder({ page })
-		.exclude(["#metricsChart"])
-		.analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });

--- a/e2e/demo/dark-accessibility.spec.ts
+++ b/e2e/demo/dark-accessibility.spec.ts
@@ -1,7 +1,6 @@
-import AxeBuilder from "@axe-core/playwright";
-import test, { expect } from "@playwright/test";
+import { expect, test } from "../axe-test";
 
-test("homepage", async ({ page }) => {
+test("homepage", async ({ page, axeBuilder }) => {
 	await page.goto("/demo");
 
 	// set dark mode
@@ -11,12 +10,12 @@ test("homepage", async ({ page }) => {
 
 	await page.waitForSelector("#loadingHome", { state: "attached" });
 
-	const results = await new AxeBuilder({ page }).analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });
 
-test("create page", async ({ page }) => {
+test("create page", async ({ page, axeBuilder }) => {
 	await page.goto("/demo/applications/create");
 
 	// set dark mode
@@ -24,14 +23,12 @@ test("create page", async ({ page }) => {
 		localStorage.setItem("theme", "dark");
 	});
 
-	const results = await new AxeBuilder({ page })
-		.exclude(["#cardColorInputAxe"])
-		.analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });
 
-test("metrics", async ({ page }) => {
+test("metrics", async ({ page, axeBuilder }) => {
 	await page.goto("/demo/applications/metrics");
 
 	// set dark mode
@@ -41,10 +38,7 @@ test("metrics", async ({ page }) => {
 
 	await page.waitForSelector("#loadingMetrics", { state: "attached" });
 
-	// exclude nivo chart as most aria is not controlled by me.
-	const results = await new AxeBuilder({ page })
-		.exclude("#metricsChart")
-		.analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });

--- a/e2e/demo/dark-accessibility.spec.ts
+++ b/e2e/demo/dark-accessibility.spec.ts
@@ -24,7 +24,9 @@ test("create page", async ({ page }) => {
 		localStorage.setItem("theme", "dark");
 	});
 
-	const results = await new AxeBuilder({ page }).analyze();
+	const results = await new AxeBuilder({ page })
+		.exclude(["#cardColorInputAxe"])
+		.analyze();
 
 	expect(results.violations).toEqual([]);
 });

--- a/e2e/landing/accessibility.spec.ts
+++ b/e2e/landing/accessibility.spec.ts
@@ -1,7 +1,6 @@
-import AxeBuilder from "@axe-core/playwright";
-import test, { expect } from "@playwright/test";
+import { expect, test } from "../axe-test";
 
-test("landing page", async ({ page }) => {
+test("landing page", async ({ page, axeBuilder }) => {
 	await page.goto("/");
 
 	// set light mode
@@ -9,10 +8,7 @@ test("landing page", async ({ page }) => {
 		localStorage.setItem("theme", "light");
 	});
 
-	// ignore particles background
-	const results = await new AxeBuilder({ page })
-		.exclude("#particlesBG")
-		.analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });

--- a/e2e/landing/dark-accessibility.spec.ts
+++ b/e2e/landing/dark-accessibility.spec.ts
@@ -1,7 +1,6 @@
-import AxeBuilder from "@axe-core/playwright";
-import test, { expect } from "@playwright/test";
+import { expect, test } from "../axe-test";
 
-test("landing page", async ({ page }) => {
+test("landing page", async ({ page, axeBuilder }) => {
 	await page.goto("/");
 
 	// set dark mode
@@ -9,10 +8,7 @@ test("landing page", async ({ page }) => {
 		localStorage.setItem("theme", "dark");
 	});
 
-	// ignore particles background
-	const results = await new AxeBuilder({ page })
-		.exclude("#particlesBG")
-		.analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });

--- a/e2e/real/accessibility.spec.ts
+++ b/e2e/real/accessibility.spec.ts
@@ -1,35 +1,29 @@
-import AxeBuilder from "@axe-core/playwright";
-import test, { expect } from "@playwright/test";
+import { expect, test } from "../axe-test";
 
-test("homepage", async ({ page }) => {
+test("homepage", async ({ page, axeBuilder }) => {
 	await page.goto("/boards");
 
 	await page.waitForSelector("#loadingHome", { state: "attached" });
 
-	const results = await new AxeBuilder({ page }).analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });
 
-test("create page", async ({ page }) => {
+test("create page", async ({ page, axeBuilder }) => {
 	await page.goto("/boards/applications/create");
 
-	const results = await new AxeBuilder({ page })
-		.exclude(["#cardColorInputAxe"])
-		.analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });
 
-test("metrics", async ({ page }) => {
+test("metrics", async ({ page, axeBuilder }) => {
 	await page.goto("/boards/applications/metrics");
 
 	await page.waitForSelector("#loadingMetrics", { state: "attached" });
 
-	// exclude nivo chart as most aria is not controlled by me.
-	const results = await new AxeBuilder({ page })
-		.exclude("#metricsChart")
-		.analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });

--- a/e2e/real/accessibility.spec.ts
+++ b/e2e/real/accessibility.spec.ts
@@ -14,7 +14,9 @@ test("homepage", async ({ page }) => {
 test("create page", async ({ page }) => {
 	await page.goto("/boards/applications/create");
 
-	const results = await new AxeBuilder({ page }).analyze();
+	const results = await new AxeBuilder({ page })
+		.exclude(["#cardColorInputAxe"])
+		.analyze();
 
 	expect(results.violations).toEqual([]);
 });

--- a/e2e/real/dark-accessibility.spec.ts
+++ b/e2e/real/dark-accessibility.spec.ts
@@ -24,7 +24,9 @@ test("create page", async ({ page }) => {
 		localStorage.setItem("theme", "dark");
 	});
 
-	const results = await new AxeBuilder({ page }).analyze();
+	const results = await new AxeBuilder({ page })
+		.exclude(["#cardColorInputAxe"])
+		.analyze();
 
 	expect(results.violations).toEqual([]);
 });

--- a/e2e/real/dark-accessibility.spec.ts
+++ b/e2e/real/dark-accessibility.spec.ts
@@ -1,7 +1,6 @@
-import AxeBuilder from "@axe-core/playwright";
-import test, { expect } from "@playwright/test";
+import { expect, test } from "../axe-test";
 
-test("homepage", async ({ page }) => {
+test("homepage", async ({ page, axeBuilder }) => {
 	await page.goto("/boards");
 
 	// set dark mode
@@ -11,12 +10,12 @@ test("homepage", async ({ page }) => {
 
 	await page.waitForSelector("#loadingHome", { state: "attached" });
 
-	const results = await new AxeBuilder({ page }).analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });
 
-test("create page", async ({ page }) => {
+test("create page", async ({ page, axeBuilder }) => {
 	await page.goto("/boards/applications/create");
 
 	// set dark mode
@@ -24,14 +23,12 @@ test("create page", async ({ page }) => {
 		localStorage.setItem("theme", "dark");
 	});
 
-	const results = await new AxeBuilder({ page })
-		.exclude(["#cardColorInputAxe"])
-		.analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });
 
-test("metrics", async ({ page }) => {
+test("metrics", async ({ page, axeBuilder }) => {
 	await page.goto("/boards/applications/metrics");
 
 	// set dark mode
@@ -41,10 +38,7 @@ test("metrics", async ({ page }) => {
 
 	await page.waitForSelector("#loadingMetrics", { state: "attached" });
 
-	// exclude nivo chart as most aria is not controlled by me.
-	const results = await new AxeBuilder({ page })
-		.exclude("#metricsChart")
-		.analyze();
+	const accessibilityResults = await axeBuilder().analyze();
 
-	expect(results.violations).toEqual([]);
+	expect(accessibilityResults.violations).toEqual([]);
 });

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next": "14.1.0",
     "next-themes": "^0.2.1",
     "react": "18.2.0",
+    "react-colorful": "^5.6.1",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.49.3",
     "react-hot-toast": "^2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   react:
     specifier: 18.2.0
     version: 18.2.0
+  react-colorful:
+    specifier: ^5.6.1
+    version: 5.6.1(react-dom@18.2.0)(react@18.2.0)
   react-dom:
     specifier: 18.2.0
     version: 18.2.0(react@18.2.0)
@@ -2776,6 +2779,16 @@ packages:
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
+
+  /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}

--- a/src/app/boards/applications/[slug]/page.tsx
+++ b/src/app/boards/applications/[slug]/page.tsx
@@ -7,7 +7,7 @@ import Modal from "@/src/components/Modals/Modal";
 import ULItem from "@/src/components/ULItem";
 import {
 	ApplicationStatusType,
-	FullApplicationType,
+	ApplicationType,
 } from "@/src/types/applications";
 import { deleteApplication, getApplication } from "@/src/utils/db";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -17,7 +17,7 @@ export default function Application() {
 	const id = Number(useSearchParams().get("id"));
 	const router = useRouter();
 
-	const [application, setApplication] = useState<FullApplicationType>();
+	const [application, setApplication] = useState<ApplicationType>();
 	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
 	function readableStatus(status: ApplicationStatusType) {
@@ -53,6 +53,7 @@ export default function Application() {
 		dateInterviewing,
 		dateOffered,
 		dateClosed,
+		cardColor,
 	} = application;
 
 	return (
@@ -123,6 +124,16 @@ export default function Application() {
 						{status === "closed" && dateClosed && (
 							<ULItem label="Closed on" body={formatDate(dateClosed)} />
 						)}
+						<li className="grid gap-1 xs:flex xs:gap-2 items-center">
+							<span className="min-w-[8rem] max-w-[8rem] font-semibold">
+								Card color:
+							</span>
+							<span
+								title={cardColor}
+								className="h-4 w-12"
+								style={{ backgroundColor: cardColor }}
+							/>
+						</li>
 					</ul>
 				</div>
 				<div className="grid w-full gap-8">

--- a/src/app/boards/applications/create/page.tsx
+++ b/src/app/boards/applications/create/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Button from "@/src/components/Button";
+import getRandomHexColor from "@/src/components/Fn/getRandomHexColor";
 import ContactFields from "@/src/components/Form/ContactFields";
+import FormCardColorInput from "@/src/components/Form/FormCardColorInput";
 import FormInput from "@/src/components/Form/FormInput";
 import FormSelectInput from "@/src/components/Form/FormSelectInput";
 import NoteFields from "@/src/components/Form/NoteFields";
@@ -46,6 +48,11 @@ export default function Create() {
 	const currentCompany = watch("company");
 
 	const currentStatus = watch("status");
+	const currentCardColor = watch("cardColor");
+
+	useEffect(() => {
+		console.log(currentCardColor, typeof currentCardColor);
+	}, [currentCardColor]);
 
 	const { usagePercent } = useStorageUsage();
 
@@ -198,6 +205,20 @@ export default function Create() {
 							error={errors.dateClosed?.message}
 							register={register}
 							className={currentStatusIndex >= 4 ? "" : "hidden"}
+						/>
+						<Controller
+							name="cardColor"
+							control={control}
+							render={({ field: { onChange } }) => (
+								<FormCardColorInput
+									id="cardColorInput"
+									label="Card Color"
+									company={currentCompany}
+									position={currentPosition}
+									color={currentCardColor ?? getRandomHexColor()}
+									setColor={onChange}
+								/>
+							)}
 						/>
 					</div>
 				</div>

--- a/src/app/boards/applications/edit/page.tsx
+++ b/src/app/boards/applications/edit/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Button from "@/src/components/Button";
+import getRandomHexColor from "@/src/components/Fn/getRandomHexColor";
 import ContactsFields from "@/src/components/Form/ContactFields";
+import FormCardColorInput from "@/src/components/Form/FormCardColorInput";
 import FormInput from "@/src/components/Form/FormInput";
 import FormSelectInput from "@/src/components/Form/FormSelectInput";
 import NoteFields from "@/src/components/Form/NoteFields";
@@ -46,6 +48,7 @@ export default function FormEdit() {
 	const currentStatus = watch("status");
 	const currentPosition = watch("position");
 	const currentCompany = watch("company");
+	const currentCardColor = watch("cardColor");
 
 	const { usagePercent } = useStorageUsage();
 
@@ -236,6 +239,20 @@ export default function FormEdit() {
 							error={errors.dateClosed?.message}
 							register={register}
 							className={currentStatusIndex >= 4 ? "" : "hidden"}
+						/>
+						<Controller
+							name="cardColor"
+							control={control}
+							render={({ field: { onChange } }) => (
+								<FormCardColorInput
+									id="cardColorInput"
+									label="Card Color"
+									company={currentCompany}
+									position={currentPosition}
+									color={currentCardColor ?? getRandomHexColor()}
+									setColor={onChange}
+								/>
+							)}
 						/>
 					</div>
 				</div>

--- a/src/app/demo/applications/[slug]/page.tsx
+++ b/src/app/demo/applications/[slug]/page.tsx
@@ -28,6 +28,7 @@ export default function Application() {
 		dateInterviewing,
 		dateOffered,
 		dateClosed,
+		cardColor,
 	} = application;
 
 	return (
@@ -76,6 +77,16 @@ export default function Application() {
 						{status === "closed" && dateClosed && (
 							<ULItem label="Closed on" body={formatDate(dateClosed)} />
 						)}
+						<li className="grid gap-1 xs:flex xs:gap-2 items-center">
+							<span className="min-w-[8rem] max-w-[8rem] font-semibold">
+								Card color:
+							</span>
+							<span
+								title={cardColor}
+								className="h-4 w-12"
+								style={{ backgroundColor: cardColor }}
+							/>
+						</li>
 					</ul>
 				</div>
 				<div className="grid w-full gap-8">

--- a/src/app/demo/applications/create/page.tsx
+++ b/src/app/demo/applications/create/page.tsx
@@ -7,7 +7,9 @@ import { z } from "zod";
 import Button from "@/src/components/Button";
 import createDemoApplication from "@/src/components/Demo/createDemoApplication";
 import getNewMockApplicationId from "@/src/components/Demo/getNewDemoApplicationId";
+import getRandomHexColor from "@/src/components/Fn/getRandomHexColor";
 import ContactFields from "@/src/components/Form/ContactFields";
+import FormCardColorInput from "@/src/components/Form/FormCardColorInput";
 import FormInput from "@/src/components/Form/FormInput";
 import FormSelectInput from "@/src/components/Form/FormSelectInput";
 import NoteFields from "@/src/components/Form/NoteFields";
@@ -48,6 +50,7 @@ export default function Create() {
 	const currentCompany = watch("company");
 
 	const currentStatus = watch("status");
+	const currentCardColor = watch("cardColor");
 
 	const { usagePercent } = useStorageUsage();
 
@@ -205,6 +208,20 @@ export default function Create() {
 							error={errors.dateClosed?.message}
 							register={register}
 							className={currentStatusIndex >= 4 ? "" : "hidden"}
+						/>
+						<Controller
+							name="cardColor"
+							control={control}
+							render={({ field: { onChange } }) => (
+								<FormCardColorInput
+									id="cardColorInput"
+									label="Card Color"
+									company={currentCompany}
+									position={currentPosition}
+									color={currentCardColor ?? getRandomHexColor()}
+									setColor={onChange}
+								/>
+							)}
 						/>
 					</div>
 				</div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -143,12 +143,6 @@
     }
   }
 
-	#cardColorInput > .react-colorful__saturation {
-		/* border-top-left-radius: 999% !important ;
-		border-top-right-radius: 0.375rem !important ; */
-		margin: 4px;
-	}
-
 	#formCardColorInputColorPicker .react-colorful {
 		width: auto;
 	}
@@ -163,6 +157,7 @@
 
 	#formCardColorInputColorPicker .react-colorful .react-colorful__pointer {
 		cursor: pointer;
+		z-index: 0;
 	}
 
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -142,4 +142,27 @@
       --gradient-border-angle: 360deg;
     }
   }
+
+	#cardColorInput > .react-colorful__saturation {
+		/* border-top-left-radius: 999% !important ;
+		border-top-right-radius: 0.375rem !important ; */
+		margin: 4px;
+	}
+
+	#formCardColorInputColorPicker .react-colorful {
+		width: auto;
+	}
+
+	#formCardColorInputColorPicker .react-colorful .react-colorful__saturation {
+		border-radius: 0.375rem 0.375rem 0px 0px;
+	}
+
+	#formCardColorInputColorPicker .react-colorful .react-colorful__last-control {
+		border-radius: 0px 0px 0.375rem 0.375rem;
+	}
+
+	#formCardColorInputColorPicker .react-colorful .react-colorful__pointer {
+		cursor: pointer;
+	}
+
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,7 +85,7 @@ export default function Home() {
 						<div className="flex animate-shift-gradient-x flex-col gap-2 rounded-md bg-gradient-to-bl from-light-primary to-light-secondary px-4 py-3 ring-2 ring-light-secondary dark:from-dark-primary dark:via-dark-primary dark:to-dark-secondary dark:ring-dark-secondary">
 							<h2 className="flex items-center gap-2 text-lg font-semibold">
 								<RectangleStackIcon
-									className="w-5 text-card-needToApply"
+									className="w-5 text-applii-needToApply"
 									aria-hidden="true"
 								/>
 								Organize applications
@@ -99,7 +99,7 @@ export default function Home() {
 						<div className="flex animate-shift-gradient-x flex-col gap-2 rounded-md bg-gradient-to-bl from-light-primary to-light-secondary px-4 py-3 ring-2 ring-light-secondary dark:from-dark-primary dark:via-dark-primary dark:to-dark-secondary dark:ring-dark-secondary">
 							<h2 className="flex items-center gap-2 text-lg font-semibold">
 								<ChartPieIcon
-									className="w-5 text-card-interviewing"
+									className="w-5 text-applii-interviewing"
 									aria-hidden="true"
 								/>
 								Monitor your progress
@@ -113,7 +113,7 @@ export default function Home() {
 						<div className="flex animate-shift-gradient-x flex-col gap-2 rounded-md bg-gradient-to-bl from-light-primary to-light-secondary px-4 py-3 ring-2 ring-light-secondary dark:from-dark-primary dark:via-dark-primary dark:to-dark-secondary dark:ring-dark-secondary">
 							<h2 className="flex items-center gap-2 text-lg font-semibold">
 								<DevicePhoneMobileIcon
-									className="w-5 text-card-offer"
+									className="w-5 text-applii-offer"
 									aria-hidden="true"
 								/>
 								Local-first
@@ -127,7 +127,7 @@ export default function Home() {
 						<div className="flex animate-shift-gradient-x flex-col gap-2 rounded-md bg-gradient-to-bl from-light-primary to-light-secondary px-4 py-3 ring-2 ring-light-secondary dark:from-dark-primary dark:via-dark-primary dark:to-dark-secondary dark:ring-dark-secondary">
 							<h2 className="flex items-center gap-2 text-lg font-semibold">
 								<LockOpenIcon
-									className="w-5 text-card-applied"
+									className="w-5 text-applii-applied"
 									aria-hidden="true"
 								/>
 								Open-source

--- a/src/components/Board/BoardSection.tsx
+++ b/src/components/Board/BoardSection.tsx
@@ -1,6 +1,6 @@
 import {
 	ApplicationStatusType,
-	FullApplicationType,
+	ApplicationType,
 	applicationStatusLabel,
 } from "@/src/types/applications";
 import { SortByValueType } from "@/src/types/global";
@@ -18,7 +18,7 @@ import BoardSectionCard from "./BoardSectionCard";
 
 export type BoardSectionProps = {
 	title: z.infer<typeof applicationStatusLabel>;
-	cards: FullApplicationType[];
+	cards: ApplicationType[];
 	sortBy: SortByValueType;
 	mode?: "demo";
 	status: ApplicationStatusType;
@@ -40,25 +40,28 @@ export default function BoardSection({
 		switch (status) {
 			case "needToApply":
 				return (
-					<ClockIcon className="w-5 text-card-needToApply" aria-hidden="true" />
+					<ClockIcon
+						className="w-5 text-applii-needToApply"
+						aria-hidden="true"
+					/>
 				);
 			case "applied":
-				return <EnvelopeIcon className="w-5 text-card-applied" />;
+				return <EnvelopeIcon className="w-5 text-applii-applied" />;
 			case "interviewing":
 				return (
 					<ChatBubbleBottomCenterTextIcon
-						className="w-5 text-card-interviewing"
+						className="w-5 text-applii-interviewing"
 						aria-hidden="true"
 					/>
 				);
 			case "offer":
 				return (
-					<TrophyIcon className="w-5 text-card-offer" aria-hidden="true" />
+					<TrophyIcon className="w-5 text-applii-offer" aria-hidden="true" />
 				);
 			case "closed":
 				return (
 					<ArchiveBoxXMarkIcon
-						className="w-5 text-card-closed"
+						className="w-5 text-applii-closed"
 						aria-hidden="true"
 					/>
 				);

--- a/src/components/Board/BoardSectionCard.tsx
+++ b/src/components/Board/BoardSectionCard.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import { SortByValueType } from "@/src/types/global";
 import Link from "next/link";
+import getContrastYIQ from "../Fn/getContrastYIQ";
 import relativeDate from "../Fn/relativeDate";
 
 export type BoardSectionCardProps = {
 	sortBy: SortByValueType;
 	mode?: "demo";
-} & FullApplicationType;
+} & ApplicationType;
 
 export default function BoardSectionCard({
 	id,
@@ -17,8 +18,8 @@ export default function BoardSectionCard({
 	dateModified,
 	dateCreated,
 	sortBy,
-	status,
 	mode,
+	cardColor,
 }: BoardSectionCardProps) {
 	const date = relativeDate(
 		sortBy === "dateCreated" ? dateCreated : dateModified,
@@ -30,11 +31,14 @@ export default function BoardSectionCard({
 			? `/demo/applications/${position}-at-${company}?id=${id}`
 			: `/boards/applications/${position}-at-${company}?id=${id}`;
 
+	const hexColor = cardColor.slice(1);
+
 	return (
 		<Link
 			href={applicationLink}
-			className={`bg-card-${status} h-board-section-card rounded-md px-3 py-2 text-black`}
+			className="h-board-section-card rounded-md px-3 py-2"
 			data-testid="board-section-card"
+			style={{ backgroundColor: cardColor, color: getContrastYIQ(hexColor) }}
 			aria-label={`Open application for ${position} at ${company}`}
 		>
 			<div className="relative flex h-full flex-col justify-between">

--- a/src/components/Board/BoardSectionCard.tsx
+++ b/src/components/Board/BoardSectionCard.tsx
@@ -3,7 +3,7 @@
 import { ApplicationType } from "@/src/types/applications";
 import { SortByValueType } from "@/src/types/global";
 import Link from "next/link";
-import getContrastYIQ from "../Fn/getContrastYIQ";
+import getContrastingColor from "../Fn/getContrastingColor";
 import relativeDate from "../Fn/relativeDate";
 
 export type BoardSectionCardProps = {
@@ -38,7 +38,11 @@ export default function BoardSectionCard({
 			href={applicationLink}
 			className="h-board-section-card rounded-md px-3 py-2"
 			data-testid="board-section-card"
-			style={{ backgroundColor: cardColor, color: getContrastYIQ(hexColor) }}
+			data-axe-ignore={true}
+			style={{
+				backgroundColor: cardColor,
+				color: getContrastingColor(hexColor),
+			}}
 			aria-label={`Open application for ${position} at ${company}`}
 		>
 			<div className="relative flex h-full flex-col justify-between">

--- a/src/components/Board/BoardSectionCardMock.tsx
+++ b/src/components/Board/BoardSectionCardMock.tsx
@@ -1,0 +1,40 @@
+import getContrastYIQ from "../Fn/getContrastYIQ";
+
+export type BoardSectionCardMockProps = {
+	bgColor: string;
+	className?: string;
+	company?: string;
+	position?: string;
+};
+
+function BoardSectionCardMock({
+	bgColor,
+	className,
+	company,
+	position,
+}: BoardSectionCardMockProps) {
+	const positionLabel =
+		position && position.length > 0 ? position : "Account Manager";
+	const companyLabel =
+		company && company.length > 0 ? company : "Leading Company";
+
+	const hexColor = bgColor.slice(1);
+
+	return (
+		<div
+			className={`h-board-section-card max-w-board-section w-full rounded-md px-3 py-2 text-black ${className}`}
+			style={{ backgroundColor: bgColor, color: getContrastYIQ(hexColor) }}
+			data-testid="board-section-card-mock"
+		>
+			<div className="relative flex h-full flex-col justify-between">
+				<div className="grid font-medium">
+					<span className="line-clamp-1">{positionLabel}</span>
+					<span className="line-clamp-1">{companyLabel}</span>
+				</div>
+				<span className="absolute bottom-0.5 right-0 text-sm">1m</span>
+			</div>
+		</div>
+	);
+}
+
+export default BoardSectionCardMock;

--- a/src/components/Board/BoardSectionCardMock.tsx
+++ b/src/components/Board/BoardSectionCardMock.tsx
@@ -1,4 +1,4 @@
-import getContrastYIQ from "../Fn/getContrastYIQ";
+import getContrastingColor from "../Fn/getContrastingColor";
 
 export type BoardSectionCardMockProps = {
 	bgColor: string;
@@ -23,8 +23,8 @@ function BoardSectionCardMock({
 	return (
 		<div
 			className={`h-board-section-card max-w-board-section w-full rounded-md px-3 py-2 text-black ${className}`}
-			style={{ backgroundColor: bgColor, color: getContrastYIQ(hexColor) }}
-			data-testid="board-section-card-mock"
+			style={{ backgroundColor: bgColor, color: getContrastingColor(hexColor) }}
+			data-axe-ignore={true}
 		>
 			<div className="relative flex h-full flex-col justify-between">
 				<div className="grid font-medium">

--- a/src/components/Demo/createDemoApplication.ts
+++ b/src/components/Demo/createDemoApplication.ts
@@ -1,9 +1,7 @@
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import getAllApplicationsInStorage from "./getAllDemoApplicationsInStorage";
 
-export default function createDemoApplication(
-	application: FullApplicationType,
-) {
+export default function createDemoApplication(application: ApplicationType) {
 	if (!window || !window.sessionStorage) return;
 
 	const applicationsInStorage = getAllApplicationsInStorage();

--- a/src/components/Demo/getAllDemoApplications.ts
+++ b/src/components/Demo/getAllDemoApplications.ts
@@ -1,6 +1,6 @@
 import {
+	ApplicationType,
 	FormatApplicationsType,
-	FullApplicationType,
 	GroupedApplicationsType,
 } from "@/src/types/applications";
 import { SortByValueType } from "@/src/types/global";
@@ -14,9 +14,7 @@ import {
 	offerMocks,
 } from "./mockDemoVariables";
 
-function getAllDemoApplications(
-	_sortBy: SortByValueType,
-): FullApplicationType[];
+function getAllDemoApplications(_sortBy: SortByValueType): ApplicationType[];
 
 function getAllDemoApplications(
 	_sortBy: SortByValueType,

--- a/src/components/Demo/getAllDemoApplicationsInStorage.ts
+++ b/src/components/Demo/getAllDemoApplicationsInStorage.ts
@@ -1,12 +1,13 @@
 import {
+	ApplicationType,
 	FormatApplicationsType,
-	FullApplicationType,
 	GroupedApplicationsType,
-	zodFullApplicationArray,
+	application,
 } from "@/src/types/applications";
+import { z } from "zod";
 import groupApplicationsByStatus from "../Fn/groupApplicationsByStatus";
 
-function getAllDemoApplicationsInStorage(): FullApplicationType[] | undefined;
+function getAllDemoApplicationsInStorage(): ApplicationType[] | undefined;
 
 function getAllDemoApplicationsInStorage(
 	_format: FormatApplicationsType,
@@ -20,9 +21,9 @@ function getAllDemoApplicationsInStorage(format?: "grouped") {
 
 	if (!applicationsInStorage) return;
 
-	const storedApps = zodFullApplicationArray.safeParse(
-		JSON.parse(applicationsInStorage),
-	);
+	const storedApps = z
+		.array(application)
+		.safeParse(JSON.parse(applicationsInStorage));
 
 	if (!storedApps.success) return;
 

--- a/src/components/Demo/mockDemoVariables.ts
+++ b/src/components/Demo/mockDemoVariables.ts
@@ -1,6 +1,6 @@
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 
-export const needToApplyMocks: FullApplicationType[] = [
+export const needToApplyMocks: ApplicationType[] = [
 	{
 		id: 1,
 		position: "Marketing Manager",
@@ -38,6 +38,7 @@ export const needToApplyMocks: FullApplicationType[] = [
 		],
 		dateCreated: "2023-06-13T04:00:00.000Z",
 		dateModified: "2023-06-13T06:00:00.000Z",
+		cardColor: "#c62828",
 	},
 	{
 		id: 2,
@@ -55,6 +56,7 @@ export const needToApplyMocks: FullApplicationType[] = [
 		notes: [],
 		dateCreated: "2023-08-28T04:00:00.000Z",
 		dateModified: "2023-08-28T06:00:00.000Z",
+		cardColor: "#1565c0",
 	},
 	{
 		id: 3,
@@ -72,6 +74,7 @@ export const needToApplyMocks: FullApplicationType[] = [
 		notes: [],
 		dateCreated: "2023-07-28T04:00:00.000Z",
 		dateModified: "2023-11-12T20:00:00.000Z",
+		cardColor: "#2e7d32",
 	},
 	{
 		id: 4,
@@ -82,6 +85,7 @@ export const needToApplyMocks: FullApplicationType[] = [
 		notes: [],
 		dateCreated: "2023-04-28T04:00:00.000Z",
 		dateModified: "2023-10-12T20:00:00.000Z",
+		cardColor: "#f9a825",
 	},
 	{
 		id: 5,
@@ -113,10 +117,11 @@ export const needToApplyMocks: FullApplicationType[] = [
 		],
 		dateCreated: "2023-04-28T04:00:00.000Z",
 		dateModified: "2023-10-12T20:00:00.000Z",
+		cardColor: "#6a1b9a",
 	},
 ];
 
-export const appliedMocks: FullApplicationType[] = [
+export const appliedMocks: ApplicationType[] = [
 	{
 		id: 6,
 		position: "Data Analyst",
@@ -131,6 +136,7 @@ export const appliedMocks: FullApplicationType[] = [
 		dateCreated: "2023-10-08T04:00:00.000Z",
 		dateModified: "2023-10-08T06:00:00.000Z",
 		dateApplied: "2023-10-10T04:00:00.000Z",
+		cardColor: "#ef6c00",
 	},
 	{
 		id: 7,
@@ -175,6 +181,7 @@ export const appliedMocks: FullApplicationType[] = [
 		dateCreated: "2023-07-17T04:00:00.000Z",
 		dateModified: "2023-07-17T06:00:00.000Z",
 		dateApplied: "2023-07-22T04:00:00.000Z",
+		cardColor: "#4e342e",
 	},
 	{
 		id: 8,
@@ -205,10 +212,11 @@ export const appliedMocks: FullApplicationType[] = [
 		dateCreated: "2023-09-03T04:00:00.000Z",
 		dateModified: "2023-10-10T06:00:00.000Z",
 		dateApplied: "2023-09-05T04:00:00.000Z",
+		cardColor: "#37474f",
 	},
 ];
 
-export const interviewingMocks: FullApplicationType[] = [
+export const interviewingMocks: ApplicationType[] = [
 	{
 		id: 9,
 		position: "Human Resources Specialist",
@@ -241,10 +249,11 @@ export const interviewingMocks: FullApplicationType[] = [
 		dateModified: "2023-05-22T06:00:00.000Z",
 		dateApplied: "2023-05-24T04:00:00.000Z",
 		dateInterviewing: "2023-05-26T04:00:00.000Z",
+		cardColor: "#ad1457",
 	},
 ];
 
-export const offerMocks: FullApplicationType[] = [
+export const offerMocks: ApplicationType[] = [
 	{
 		id: 10,
 		position: "Human Resources Specialist",
@@ -267,6 +276,7 @@ export const offerMocks: FullApplicationType[] = [
 		dateApplied: "2023-10-06T04:00:00.000Z",
 		dateInterviewing: "2023-10-08T04:00:00.000Z",
 		dateOffered: "2023-10-10T04:00:00.000Z",
+		cardColor: "#00838f",
 	},
 	{
 		id: 11,
@@ -293,10 +303,11 @@ export const offerMocks: FullApplicationType[] = [
 		dateApplied: "2023-11-09T04:00:00.000Z",
 		dateInterviewing: "2023-11-11T04:00:00.000Z",
 		dateOffered: "2023-11-13T04:00:00.000Z",
+		cardColor: "#fdd835",
 	},
 ];
 
-export const closedMocks: FullApplicationType[] = [
+export const closedMocks: ApplicationType[] = [
 	{
 		id: 12,
 		position: "Sales Representative",
@@ -324,6 +335,7 @@ export const closedMocks: FullApplicationType[] = [
 		dateInterviewing: "2023-11-09T04:00:00.000Z",
 		dateOffered: "2023-11-11T04:00:00.000Z",
 		dateClosed: "2023-11-13T04:00:00.000Z",
+		cardColor: "#009688",
 	},
 ];
 

--- a/src/components/Fn/getContrastYIQ.ts
+++ b/src/components/Fn/getContrastYIQ.ts
@@ -1,0 +1,17 @@
+/**
+ * Takes a hex color and returns the best color for readability, either black or white
+ * See https://en.wikipedia.org/wiki/YIQ for details
+ */
+function getContrastYIQ(hexcolor: string) {
+	if (hexcolor[0] === "#") {
+		throw new Error(
+			"Incorrect hex color passed. Remove the # from the hex passed",
+		);
+	}
+	const r = parseInt(hexcolor.substring(0, 2), 16);
+	const g = parseInt(hexcolor.substring(2, 4), 16);
+	const b = parseInt(hexcolor.substring(4, 6), 16);
+	const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+	return yiq >= 128 ? "black" : "white";
+}
+export default getContrastYIQ;

--- a/src/components/Fn/getContrastingColor.ts
+++ b/src/components/Fn/getContrastingColor.ts
@@ -2,16 +2,17 @@
  * Takes a hex color and returns the best color for readability, either black or white
  * See https://en.wikipedia.org/wiki/YIQ for details
  */
-function getContrastYIQ(hexcolor: string) {
-	if (hexcolor[0] === "#") {
+function getContrastingColor(hexColor: string) {
+	if (hexColor[0] === "#") {
 		throw new Error(
 			"Incorrect hex color passed. Remove the # from the hex passed",
 		);
 	}
-	const r = parseInt(hexcolor.substring(0, 2), 16);
-	const g = parseInt(hexcolor.substring(2, 4), 16);
-	const b = parseInt(hexcolor.substring(4, 6), 16);
+
+	const r = parseInt(hexColor.substring(0, 2), 16);
+	const g = parseInt(hexColor.substring(2, 4), 16);
+	const b = parseInt(hexColor.substring(4, 6), 16);
 	const yiq = (r * 299 + g * 587 + b * 114) / 1000;
 	return yiq >= 128 ? "black" : "white";
 }
-export default getContrastYIQ;
+export default getContrastingColor;

--- a/src/components/Fn/getRandomHexColor.ts
+++ b/src/components/Fn/getRandomHexColor.ts
@@ -1,0 +1,14 @@
+function getRandomHexColor() {
+	let hexColor = "";
+
+	for (let i = 0; i < 6; i++) {
+		const index = Math.floor(Math.random() * 16);
+		const digit = index.toString(16);
+
+		hexColor = `${hexColor}${digit}`;
+	}
+
+	return `#${hexColor}`;
+}
+
+export default getRandomHexColor;

--- a/src/components/Fn/groupApplicationsByStatus.ts
+++ b/src/components/Fn/groupApplicationsByStatus.ts
@@ -1,13 +1,13 @@
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 
 export default function groupApplicationsByStatus(
-	applications: FullApplicationType[],
+	applications: ApplicationType[],
 ) {
-	const needToApply: FullApplicationType[] = [];
-	const applied: FullApplicationType[] = [];
-	const interviewing: FullApplicationType[] = [];
-	const offer: FullApplicationType[] = [];
-	const closed: FullApplicationType[] = [];
+	const needToApply: ApplicationType[] = [];
+	const applied: ApplicationType[] = [];
+	const interviewing: ApplicationType[] = [];
+	const offer: ApplicationType[] = [];
+	const closed: ApplicationType[] = [];
 
 	for (let i = 0; i < applications.length; i++) {
 		const application = applications[i];

--- a/src/components/Fn/sortApplicationsByDate.ts
+++ b/src/components/Fn/sortApplicationsByDate.ts
@@ -1,9 +1,9 @@
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import { SortByValueType } from "@/src/types/global";
 import dayjs from "dayjs";
 
 export type SortApplicationsByDateProps = {
-	applications: FullApplicationType[];
+	applications: ApplicationType[];
 	sortBy: SortByValueType;
 };
 

--- a/src/components/Form/FormCardColorInput.tsx
+++ b/src/components/Form/FormCardColorInput.tsx
@@ -33,7 +33,7 @@ function FormCardColorInput({
 	if (!isMounted) return <div className="h-[304px]" />;
 
 	return (
-		<div className="grid gap-1" id={`${id}Axe`}>
+		<div className="grid gap-1" data-axe-ignore={true}>
 			<div className="flex flex-col md:flex-row md:gap-1">
 				<label
 					htmlFor={id}

--- a/src/components/Form/FormCardColorInput.tsx
+++ b/src/components/Form/FormCardColorInput.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { HexColorPicker } from "react-colorful";
+import BoardSectionCardMock from "../Board/BoardSectionCardMock";
+import ErrorMessage from "./ErrorMessage";
+
+export type FormColorInputProps = {
+	id: string;
+	label: string;
+	color: string;
+	setColor: React.Dispatch<React.SetStateAction<string>>;
+	error?: string;
+	position?: string;
+	company?: string;
+};
+
+function FormCardColorInput({
+	id,
+	label,
+	color,
+	setColor,
+	error,
+	company,
+	position,
+}: FormColorInputProps) {
+	const [isMounted, setIsMounted] = useState(false);
+
+	useEffect(() => {
+		setIsMounted(true);
+	}, []);
+
+	if (!isMounted) return <div className="h-[304px]" />;
+
+	return (
+		<div className="grid gap-1" id={`${id}Axe`}>
+			<div className="flex flex-col md:flex-row md:gap-1">
+				<label
+					htmlFor={id}
+					className="mb-1 ml-1 flex gap-1 text-sm leading-tight opacity-80 md:w-32"
+				>
+					{label}
+				</label>
+				<div className="md:items-center flex-col flex w-full gap-3">
+					<div id="formCardColorInputColorPicker" className="w-full">
+						<HexColorPicker id={id} color={color} onChange={setColor} />
+					</div>
+					<BoardSectionCardMock
+						company={company}
+						position={position}
+						bgColor={color}
+					/>
+				</div>
+			</div>
+			<ErrorMessage error={error} />
+		</div>
+	);
+}
+
+export default FormCardColorInput;

--- a/src/components/Landing/BoardSection.tsx
+++ b/src/components/Landing/BoardSection.tsx
@@ -1,11 +1,11 @@
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import { PlusCircleIcon } from "@heroicons/react/24/outline";
 import { ClockIcon, TrophyIcon } from "@heroicons/react/24/solid";
 import BoardSectionCard from "./BoardSectionCard";
 
 export type LandingBoardSectionProps = {
 	title: "Need To Apply" | "Offer";
-	cards: FullApplicationType[];
+	cards: ApplicationType[];
 	className?: string;
 };
 
@@ -22,11 +22,11 @@ export default function BoardSection({
 				<h2 className="flex gap-2 text-lg font-medium">
 					{title === "Need To Apply" ? (
 						<ClockIcon
-							className="w-5 text-card-needToApply"
+							className="w-5 text-applii-needToApply"
 							aria-hidden="true"
 						/>
 					) : (
-						<TrophyIcon className="w-5 text-card-offer" aria-hidden="true" />
+						<TrophyIcon className="w-5 text-applii-offer" aria-hidden="true" />
 					)}
 					<span>{title}</span>
 				</h2>

--- a/src/components/Landing/BoardSectionCard.tsx
+++ b/src/components/Landing/BoardSectionCard.tsx
@@ -1,5 +1,5 @@
 import { ApplicationType } from "@/src/types/applications";
-import getContrastYIQ from "../Fn/getContrastYIQ";
+import getContrastingColor from "../Fn/getContrastingColor";
 import relativeDate from "../Fn/relativeDate";
 
 export default function BoardSectionCard({
@@ -15,7 +15,11 @@ export default function BoardSectionCard({
 	return (
 		<div
 			className="h-board-section-card rounded-md px-3 py-2 text-black"
-			style={{ backgroundColor: cardColor, color: getContrastYIQ(hexColor) }}
+			style={{
+				backgroundColor: cardColor,
+				color: getContrastingColor(hexColor),
+			}}
+			data-axe-ignore={true}
 		>
 			<div className="relative flex h-full flex-col justify-between">
 				<div className="grid font-medium">

--- a/src/components/Landing/BoardSectionCard.tsx
+++ b/src/components/Landing/BoardSectionCard.tsx
@@ -1,17 +1,21 @@
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
+import getContrastYIQ from "../Fn/getContrastYIQ";
 import relativeDate from "../Fn/relativeDate";
 
 export default function BoardSectionCard({
 	position,
 	company,
 	dateCreated,
-	status,
-}: FullApplicationType) {
+	cardColor,
+}: ApplicationType) {
 	const date = relativeDate(dateCreated, "dateCreated");
+
+	const hexColor = cardColor.slice(1);
 
 	return (
 		<div
-			className={`bg-card-${status} h-board-section-card rounded-md px-3 py-2 text-black`}
+			className="h-board-section-card rounded-md px-3 py-2 text-black"
+			style={{ backgroundColor: cardColor, color: getContrastYIQ(hexColor) }}
 		>
 			<div className="relative flex h-full flex-col justify-between">
 				<div className="grid font-medium">

--- a/src/components/Landing/StarryCanvas.tsx
+++ b/src/components/Landing/StarryCanvas.tsx
@@ -93,9 +93,9 @@ export default function StarryCanvas() {
 	if (init)
 		return (
 			<Particles
-				id="particlesBG"
 				className="pointer-events-none fixed z-[-1] h-full w-full"
 				options={options}
+				data-axe-ignore={true}
 			/>
 		);
 

--- a/src/components/Metrics/Chart.tsx
+++ b/src/components/Metrics/Chart.tsx
@@ -45,8 +45,8 @@ export function Chart({ data, totalApplications }: ChartProps) {
 				<p>Rotate your device to view the chart</p>
 			</div>
 			<div
-				id="metricsChart"
 				className="mb-4 hidden h-96 w-full overflow-hidden text-light-text dark:text-dark-text sm:flex"
+				data-axe-ignore={true}
 			>
 				<ResponsiveBar
 					data={data}

--- a/src/components/Metrics/formatApplicationData.ts
+++ b/src/components/Metrics/formatApplicationData.ts
@@ -1,4 +1,4 @@
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import { statusColors } from "@/src/types/global";
 import {
 	ApplicationsInDateRangeType,
@@ -11,11 +11,11 @@ export default function formatApplicationData(
 	const dataFormatted = data.map((data) => {
 		const { label, applications } = data;
 
-		const needToApplyApps: FullApplicationType[] = [];
-		const appliedApps: FullApplicationType[] = [];
-		const interviewingApps: FullApplicationType[] = [];
-		const offerApps: FullApplicationType[] = [];
-		const closedApps: FullApplicationType[] = [];
+		const needToApplyApps: ApplicationType[] = [];
+		const appliedApps: ApplicationType[] = [];
+		const interviewingApps: ApplicationType[] = [];
+		const offerApps: ApplicationType[] = [];
+		const closedApps: ApplicationType[] = [];
 
 		for (const application of applications) {
 			const status = application.status;

--- a/src/components/Metrics/generateMetrics.ts
+++ b/src/components/Metrics/generateMetrics.ts
@@ -1,4 +1,4 @@
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import { TimelineType } from "@/src/types/global";
 import { FormattedChartDataType } from "@/src/types/metrics";
 import formatApplicationData from "./formatApplicationData";
@@ -9,7 +9,7 @@ import groupApplicationsByDateRange from "./groupApplicationsByDateRange";
 
 export type GenerateMetricsProps = {
 	timeline: TimelineType;
-	applications: FullApplicationType[];
+	applications: ApplicationType[];
 };
 
 export type GenerateMetricsReturnType = {

--- a/src/components/Metrics/groupApplicationsByDateRange.ts
+++ b/src/components/Metrics/groupApplicationsByDateRange.ts
@@ -1,4 +1,4 @@
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import { TimelineType } from "@/src/types/global";
 import {
 	ApplicationsInDateRangeType,
@@ -9,7 +9,7 @@ import isBetween from "dayjs/plugin/isBetween";
 dayjs.extend(isBetween);
 
 export type GroupApplicationsByDateRangeProps = {
-	applications: FullApplicationType[];
+	applications: ApplicationType[];
 	timeline: TimelineType;
 };
 

--- a/src/components/PromiseLink.tsx
+++ b/src/components/PromiseLink.tsx
@@ -91,7 +91,7 @@ export default function PromiseLink({
 				aria-label="error"
 				className={`${defaultFocusHoverClasses} pointer-events-none flex h-fit min-w-button cursor-wait items-center justify-center gap-1 whitespace-nowrap rounded-md bg-light-secondary px-5 py-1.5 text-center text-sm font-medium dark:bg-dark-secondary ${className}`}
 			>
-				<XCircleIcon className="w-6 text-card-closed" aria-hidden="true" />
+				<XCircleIcon className="w-6 text-applii-closed" aria-hidden="true" />
 				{error}
 			</div>
 		);

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -14,13 +14,16 @@ export default function Toaster() {
 				},
 				error: {
 					icon: (
-						<XCircleIcon className="w-6 text-card-closed" aria-hidden="true" />
+						<XCircleIcon
+							className="w-6 text-applii-closed"
+							aria-hidden="true"
+						/>
 					),
 				},
 				success: {
 					icon: (
 						<CheckCircleIcon
-							className="w-6 text-card-applied"
+							className="w-6 text-applii-applied"
 							aria-hidden="true"
 						/>
 					),

--- a/src/types/applications.ts
+++ b/src/types/applications.ts
@@ -20,7 +20,7 @@ export const applicationStatuses = z.enum([
 	"closed",
 ]);
 
-export const zodFullApplication = z.object({
+export const application = z.object({
 	id: z.number(),
 	position: z.string(),
 	company: z.string(),
@@ -49,50 +49,10 @@ export const zodFullApplication = z.object({
 			}),
 		)
 		.optional(),
+	cardColor: z.string(),
 });
 
-export const zodFullApplicationArray = z.array(zodFullApplication);
-
-export type ApplicationType = {
-	id: number;
-	position: string;
-	company: string;
-	postingURL?: string;
-	status: ApplicationStatusType;
-	dateCreated: string;
-	dateModified: string;
-	dateApplied?: string;
-	dateInterviewing?: string;
-	dateOffered?: string;
-	dateClosed?: string;
-};
-
-export type CreateApplicationType = {
-	position: string;
-	company: string;
-	postingURL?: string;
-	status: ApplicationStatusType;
-	dateApplied?: string;
-	dateInterviewing?: string;
-	dateOffered?: string;
-	dateClosed?: string;
-	notes?: NotesType[];
-	contacts?: ContactType[];
-};
-
-export type UpdateApplicationType = {
-	id: number;
-	position: string;
-	company: string;
-	postingURL?: string;
-	status: ApplicationStatusType;
-	dateApplied?: string;
-	dateInterviewing?: string;
-	dateOffered?: string;
-	dateClosed?: string;
-	notes?: NotesType[];
-	contacts?: ContactType[];
-};
+export type ApplicationType = z.infer<typeof application>;
 
 export type NotesType = {
 	body: string;
@@ -104,11 +64,6 @@ export type ContactType = {
 	phone?: string;
 	email?: string;
 };
-
-export type FullApplicationType = {
-	notes?: NotesType[];
-	contacts?: ContactType[];
-} & ApplicationType;
 
 export type ApplicationStatusLabelValueType = {
 	label: z.infer<typeof applicationStatusLabel>;
@@ -146,6 +101,7 @@ export const formSchema = z.object({
 		)
 		.optional(),
 	notes: z.array(z.object({ body: z.string() })).optional(),
+	cardColor: z.string(),
 });
 
 export type FormContextType = {
@@ -173,11 +129,11 @@ export type ArrayFieldProps = {
 };
 
 export type GroupedApplicationsType = {
-	needToApply: FullApplicationType[];
-	applied: FullApplicationType[];
-	interviewing: FullApplicationType[];
-	offer: FullApplicationType[];
-	closed: FullApplicationType[];
+	needToApply: ApplicationType[];
+	applied: ApplicationType[];
+	interviewing: ApplicationType[];
+	offer: ApplicationType[];
+	closed: ApplicationType[];
 };
 
 export type FormatApplicationsType = "grouped";

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { FullApplicationType, zodFullApplicationArray } from "./applications";
+import { ApplicationType, application } from "./applications";
 
 const SettingsNames = z.enum(["syncInterval", "theme"]);
 
@@ -21,11 +21,11 @@ export const syncSettingsSchema = z.object({
 });
 
 export const AllData = z.object({
-	applications: zodFullApplicationArray,
+	applications: z.array(application),
 	settings: SettingsArrayType,
 });
 
 export type ImportExportDataType = {
-	applications: FullApplicationType[];
+	applications: ApplicationType[];
 	settings: SettingsType[];
 };

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,3 +1,5 @@
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
+
 type GrowToSizeType<
 	T,
 	N extends number,

--- a/src/types/landing.ts
+++ b/src/types/landing.ts
@@ -1,9 +1,9 @@
 import dayjs from "dayjs";
-import { FullApplicationType } from "./applications";
+import { ApplicationType } from "./applications";
 
 const currentDate = dayjs();
 
-export const needToApplyMocks: FullApplicationType[] = [
+export const needToApplyMocks: ApplicationType[] = [
 	{
 		id: 2,
 		position: "Project Coordinator",
@@ -13,6 +13,7 @@ export const needToApplyMocks: FullApplicationType[] = [
 		notes: [],
 		dateCreated: currentDate.subtract(1, "week").toISOString(),
 		dateModified: "2023-08-28T06:00:00.000Z",
+		cardColor: "#30C5D2",
 	},
 	{
 		id: 3,
@@ -23,6 +24,7 @@ export const needToApplyMocks: FullApplicationType[] = [
 		notes: [],
 		dateCreated: currentDate.subtract(3, "week").toISOString(),
 		dateModified: "2023-11-12T20:00:00.000Z",
+		cardColor: "#6EF195",
 	},
 	{
 		id: 1,
@@ -34,6 +36,7 @@ export const needToApplyMocks: FullApplicationType[] = [
 		notes: [],
 		dateCreated: currentDate.subtract(1, "month").toISOString(),
 		dateModified: "2023-06-13T06:00:00.000Z",
+		cardColor: "#1C90BF",
 	},
 	{
 		id: 5,
@@ -44,6 +47,7 @@ export const needToApplyMocks: FullApplicationType[] = [
 		notes: [],
 		dateCreated: currentDate.subtract(1.5, "month").toISOString(),
 		dateModified: "2023-10-12T20:00:00.000Z",
+		cardColor: "#FCB0F3",
 	},
 	{
 		id: 4,
@@ -54,10 +58,11 @@ export const needToApplyMocks: FullApplicationType[] = [
 		notes: [],
 		dateCreated: currentDate.subtract(3, "month").toISOString(),
 		dateModified: "2023-10-12T20:00:00.000Z",
+		cardColor: "#1A2766",
 	},
 ];
 
-export const offerMocks: FullApplicationType[] = [
+export const offerMocks: ApplicationType[] = [
 	{
 		id: 11,
 		position: "Sales Representative",
@@ -70,6 +75,7 @@ export const offerMocks: FullApplicationType[] = [
 		dateApplied: "2023-11-09T04:00:00.000Z",
 		dateInterviewing: "2023-11-11T04:00:00.000Z",
 		dateOffered: "2023-11-13T04:00:00.000Z",
+		cardColor: "#FCB0F3",
 	},
 	{
 		id: 10,
@@ -83,5 +89,6 @@ export const offerMocks: FullApplicationType[] = [
 		dateApplied: "2023-10-06T04:00:00.000Z",
 		dateInterviewing: "2023-10-08T04:00:00.000Z",
 		dateOffered: "2023-10-10T04:00:00.000Z",
+		cardColor: "#F8997D",
 	},
 ];

--- a/src/types/metrics.ts
+++ b/src/types/metrics.ts
@@ -1,4 +1,4 @@
-import { FullApplicationType } from "./applications";
+import { ApplicationType } from "./applications";
 
 export type ChartDataType = {
 	date: string;
@@ -19,7 +19,7 @@ export const chartStageKeys = [
 
 export type ApplicationsInDateRangeType = {
 	label: string;
-	applications: FullApplicationType[];
+	applications: ApplicationType[];
 };
 
 export const timelineUnits = {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -47,7 +47,7 @@ const config: Config = {
 					tertiary: "#dadad8",
 					text: "#37352f",
 				},
-				card: {
+				applii: {
 					needToApply: "#ADD8E6",
 					applied: "#22C55E",
 					interviewing: "#FFDB58",
@@ -99,11 +99,6 @@ const config: Config = {
 		hoverOnlyWhenSupported: true,
 	},
 	safelist: [
-		"bg-card-needToApply",
-		"bg-card-applied",
-		"bg-card-interviewing",
-		"bg-card-offer",
-		"bg-card-closed",
 		"outline-none",
 		"transition-colors",
 		"focus-within:outline-none",

--- a/tests/getContrastYIQ.spec.ts
+++ b/tests/getContrastYIQ.spec.ts
@@ -1,0 +1,64 @@
+import getContrastYIQ from "@/src/components/Fn/getContrastYIQ";
+import { describe, expect, test } from "vitest";
+
+describe("is black text readable", () => {
+	test("returns black", () => {
+		const result = getContrastYIQ("ffffff");
+
+		expect(result).toEqual("black");
+	});
+
+	test("returns white", () => {
+		const result = getContrastYIQ("000000");
+
+		expect(result).toEqual("white");
+	});
+
+	test("returns white", () => {
+		const result = getContrastYIQ("EF4444");
+
+		expect(result).toEqual("white");
+	});
+
+	test("returns black", () => {
+		const result = getContrastYIQ("FAA31B");
+
+		expect(result).toEqual("black");
+	});
+
+	test("returns black", () => {
+		const result = getContrastYIQ("FFF000");
+
+		expect(result).toEqual("black");
+	});
+
+	test("returns black", () => {
+		const result = getContrastYIQ("82C341");
+
+		expect(result).toEqual("black");
+	});
+
+	test("returns white", () => {
+		const result = getContrastYIQ("009F75");
+
+		expect(result).toEqual("white");
+	});
+
+	test("returns black", () => {
+		const result = getContrastYIQ("88C6ED");
+
+		expect(result).toEqual("black");
+	});
+
+	test("returns white", () => {
+		const result = getContrastYIQ("394BA0");
+
+		expect(result).toEqual("white");
+	});
+
+	test("returns white", () => {
+		const result = getContrastYIQ("D54799");
+
+		expect(result).toEqual("white");
+	});
+});

--- a/tests/getContrastingColor.spec.ts
+++ b/tests/getContrastingColor.spec.ts
@@ -1,63 +1,63 @@
-import getContrastYIQ from "@/src/components/Fn/getContrastYIQ";
+import getContrastingColor from "@/src/components/Fn/getContrastingColor";
 import { describe, expect, test } from "vitest";
 
 describe("is black text readable", () => {
 	test("returns black", () => {
-		const result = getContrastYIQ("ffffff");
+		const result = getContrastingColor("ffffff");
 
 		expect(result).toEqual("black");
 	});
 
 	test("returns white", () => {
-		const result = getContrastYIQ("000000");
+		const result = getContrastingColor("000000");
 
 		expect(result).toEqual("white");
 	});
 
 	test("returns white", () => {
-		const result = getContrastYIQ("EF4444");
+		const result = getContrastingColor("EF4444");
 
 		expect(result).toEqual("white");
 	});
 
 	test("returns black", () => {
-		const result = getContrastYIQ("FAA31B");
+		const result = getContrastingColor("FAA31B");
 
 		expect(result).toEqual("black");
 	});
 
 	test("returns black", () => {
-		const result = getContrastYIQ("FFF000");
+		const result = getContrastingColor("FFF000");
 
 		expect(result).toEqual("black");
 	});
 
 	test("returns black", () => {
-		const result = getContrastYIQ("82C341");
+		const result = getContrastingColor("82C341");
 
 		expect(result).toEqual("black");
 	});
 
 	test("returns white", () => {
-		const result = getContrastYIQ("009F75");
+		const result = getContrastingColor("009F75");
 
 		expect(result).toEqual("white");
 	});
 
 	test("returns black", () => {
-		const result = getContrastYIQ("88C6ED");
+		const result = getContrastingColor("88C6ED");
 
 		expect(result).toEqual("black");
 	});
 
 	test("returns white", () => {
-		const result = getContrastYIQ("394BA0");
+		const result = getContrastingColor("394BA0");
 
 		expect(result).toEqual("white");
 	});
 
 	test("returns white", () => {
-		const result = getContrastYIQ("D54799");
+		const result = getContrastingColor("D54799");
 
 		expect(result).toEqual("white");
 	});

--- a/tests/groupApplicationsByStatus.spec.ts
+++ b/tests/groupApplicationsByStatus.spec.ts
@@ -1,5 +1,5 @@
 import groupApplicationsByStatus from "@/src/components/Fn/groupApplicationsByStatus";
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import { expect, test } from "vitest";
 
 test("groups applications by status", () => {
@@ -158,7 +158,7 @@ test("groups applications by status", () => {
 	});
 });
 
-const applications: FullApplicationType[] = [
+const applications: ApplicationType[] = [
 	{
 		id: 1,
 		position: "Marketing Manager",

--- a/tests/metrics/generateMetrics.spec.ts
+++ b/tests/metrics/generateMetrics.spec.ts
@@ -1,5 +1,5 @@
 import generateMetrics from "@/src/components/Metrics/generateMetrics";
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import { statusColors } from "@/src/types/global";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -495,7 +495,7 @@ describe("generates metrics", () => {
 	});
 });
 
-const applications: FullApplicationType[] = [
+const applications: ApplicationType[] = [
 	{
 		id: 1,
 		position: "Marketing Manager",

--- a/tests/metrics/groupApplicationsByDateRange.spec.ts
+++ b/tests/metrics/groupApplicationsByDateRange.spec.ts
@@ -1,5 +1,5 @@
 import groupApplicationsByDateRange from "@/src/components/Metrics/groupApplicationsByDateRange";
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 describe("group applications by date range", () => {
@@ -399,7 +399,7 @@ describe("group applications by date range", () => {
 	});
 });
 
-const applications: FullApplicationType[] = [
+const applications: ApplicationType[] = [
 	{
 		id: 1,
 		position: "Marketing Manager",

--- a/tests/sortApplicationsByDate.spec.ts
+++ b/tests/sortApplicationsByDate.spec.ts
@@ -1,5 +1,5 @@
 import sortApplicationsByDate from "@/src/components/Fn/sortApplicationsByDate";
-import { FullApplicationType } from "@/src/types/applications";
+import { ApplicationType } from "@/src/types/applications";
 import { describe, expect, test } from "vitest";
 
 describe("sorts applications in desc order", () => {
@@ -302,7 +302,7 @@ describe("sorts applications in desc order", () => {
 	});
 });
 
-const applications: FullApplicationType[] = [
+const applications: ApplicationType[] = [
 	{
 		id: 1,
 		position: "Marketing Manager",


### PR DESCRIPTION
## Description
Add the option to add custom colors for the board section cards when creating/updating an application #38. Also fixes biome hanging because it was trying to lint .next folder.

## Todo
- [x] Ran the tests with `pnpm test`
- [x] Linted with `pnpm lint`
- [ ] Documentation updates
