### PR TITLE
feat: add last successful sync message in settings page

### DIFF
--- a/src/app/boards/settings/page.tsx
+++ b/src/app/boards/settings/page.tsx
@@ -28,11 +28,14 @@ import {
 	ArrowUpTrayIcon,
 } from "@heroicons/react/24/outline";
 import { zodResolver } from "@hookform/resolvers/zod";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import { z } from "zod";
+dayjs.extend(relativeTime);
 
 export default function Settings() {
 	const { triggerSync } = useSync();
@@ -50,6 +53,8 @@ export default function Settings() {
 	const [showFileImportModal, setShowFileImportModal] = useState(false);
 
 	const [isMounted, setIsMounted] = useState(false);
+
+	const [lastSuccessfulSync, setLastSuccessfulSync] = useState("Never");
 
 	function submitSyncSettings() {
 		const { syncInterval } = getFormSettingValues();
@@ -164,6 +169,12 @@ export default function Settings() {
 		getAllSettings().then((allSettings) => {
 			const syncInterval = allSettings.find(
 				(setting) => setting.name === "syncInterval",
+			);
+			const lastSynced = allSettings.find(
+				(setting) => setting.name === "lastSuccessfulSync",
+			);
+			setLastSuccessfulSync(
+				lastSynced ? dayjs(lastSynced.value).fromNow() : "Never",
 			);
 			setFormSettingValue(
 				"syncInterval",
@@ -303,6 +314,7 @@ export default function Settings() {
 					<div className="mb-6 space-y-1">
 						<h2 className="text-xl font-medium">Sync</h2>
 						<p className="text-sm">Edit your sync settings</p>
+						<p className="text-sm">Last synced {lastSuccessfulSync}</p>
 					</div>
 					<div className="grid gap-4">
 						<Button onClick={() => triggerSync()}>Trigger sync manually</Button>

--- a/src/components/SyncProvider.tsx
+++ b/src/components/SyncProvider.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { getSetting } from "@/src/utils/db";
+import { getSetting, updateSetting } from "@/src/utils/db";
 import syncData from "@/src/utils/syncData";
+import dayjs from "dayjs";
 import {
 	createContext,
 	useCallback,
@@ -36,7 +37,12 @@ export default function SyncProvider({
 
 	const triggerSync = useCallback(() => {
 		if (forceStop) return;
-		const syncPromise = syncData();
+		const syncPromise = syncData().then(() =>
+			updateSetting({
+				name: "lastSuccessfulSync",
+				value: dayjs().toISOString(),
+			}),
+		);
 
 		toast.promise(syncPromise, {
 			success: "Synced successfully",

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,17 +1,16 @@
 import { z } from "zod";
 import { ApplicationType, application } from "./applications";
 
-const SettingsNames = z.enum(["syncInterval", "theme"]);
+const SettingsNames = z.enum(["syncInterval", "theme", "lastSuccessfulSync"]);
 
 export type SettingsNameType = z.infer<typeof SettingsNames>;
 
-export const SettingType = z.object({ name: SettingsNames, value: z.string() });
+export const settingsKeyValue = z.object({
+	name: SettingsNames,
+	value: z.string(),
+});
 
-export type SettingsType = z.infer<typeof SettingType>;
-
-export const SettingsArrayType = z.array(
-	z.object({ name: SettingsNames, value: z.string() }),
-);
+export type SettingsType = z.infer<typeof settingsKeyValue>;
 
 export const syncSettingsSchema = z.object({
 	syncInterval: z
@@ -20,9 +19,9 @@ export const syncSettingsSchema = z.object({
 		.optional(),
 });
 
-export const AllData = z.object({
+export const allData = z.object({
 	applications: z.array(application),
-	settings: SettingsArrayType,
+	settings: z.array(settingsKeyValue),
 });
 
 export type ImportExportDataType = {

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -9,12 +9,11 @@ import {
 	application,
 } from "../types/applications";
 import {
-	AllData,
 	ImportExportDataType,
-	SettingType,
-	SettingsArrayType,
 	SettingsNameType,
 	SettingsType,
+	allData,
+	settingsKeyValue,
 } from "../types/db";
 import { Optional, SortByValueType, promiseSeries } from "../types/global";
 
@@ -270,12 +269,13 @@ export async function getAllSettings(): Promise<SettingsType[]> {
 		data.onerror = (error) =>
 			reject(`Unable to fetch all settings from database. Error: ${error}`);
 		data.onsuccess = () => {
-			console.log(data);
 			resolve(data.result);
 		};
 	});
 
-	const parsedSettingsData = SettingsArrayType.safeParse(rawSettingsData);
+	const parsedSettingsData = z
+		.array(settingsKeyValue)
+		.safeParse(rawSettingsData);
 
 	if (!parsedSettingsData.success) {
 		throw new Error(
@@ -305,7 +305,7 @@ export async function getSetting({
 		return undefined;
 	}
 
-	const parsedSettingData = SettingType.safeParse(rawSettingData);
+	const parsedSettingData = settingsKeyValue.safeParse(rawSettingData);
 
 	if (!parsedSettingData.success) {
 		throw new Error(
@@ -352,7 +352,7 @@ export async function getAllData(): Promise<{
 		);
 	});
 
-	const parsedData = AllData.safeParse(rawData);
+	const parsedData = allData.safeParse(rawData);
 
 	if (!parsedData.success) {
 		throw new Error(


### PR DESCRIPTION
## Description
#82 adds a message in the sync section of the settings page that says when the last sync was successful. If no sync was successful or performed it will show "never"

## Todo
- [x] Ran the tests with `pnpm test`
- [x] Linted with `pnpm lint`
- [ ] Documentation updates
